### PR TITLE
Remove orderBy clauses in aggregate function

### DIFF
--- a/src/Repository/DataEntryRepository.php
+++ b/src/Repository/DataEntryRepository.php
@@ -84,6 +84,7 @@ class DataEntryRepository extends ServiceEntityRepository
     public function findByLocationTopicYearTotal(?Location $location = null, ?Topic $topic = null, ?int $yearFrom = null, ?int $yearTo = null): int
     {
         return $this->createLocationTopicYearQuery($location, $topic, $yearFrom, $yearTo)
+            ->resetDQLPart('orderBy')
             ->select('COUNT(d.id) AS total')
             ->getQuery()
             ->getOneOrNullResult()['total'];


### PR DESCRIPTION
In MySQL hat es keine Probleme, wenn man eine Aggregate Function benutzt mit OrderBy Clauses (dies wird von MySQL einfach ignoriert). Bei Postgres darf es aber kein orderby haben.